### PR TITLE
Fix multiple issues when switching mode.

### DIFF
--- a/src/headers/plasmastyle.h
+++ b/src/headers/plasmastyle.h
@@ -15,8 +15,6 @@ public:
 
     void setPlasmaStyle(QString plasmaStyle);
 
-    void setPlasmaStyleBreeze();
-
 private:
     QProcess *styleProcess;
 };

--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -72,8 +72,9 @@ private:
     QDBusInterface *notifyInterface;
     QProcess *plasmaDesktopProcess;
     QProcess *latteProcess;
-    QProcess *killAllProcess;
+    QProcess *kquitapp5Process;
     QProcess *kstart5Process;
+    QProcess *krunnerProcess;
 };
 
 #endif // UTILS_H

--- a/src/plasmastyle.cpp
+++ b/src/plasmastyle.cpp
@@ -7,12 +7,10 @@ PlasmaStyle::PlasmaStyle()
 
 void PlasmaStyle::setPlasmaStyle(QString plasmaStyle)
 {
-    KSharedConfigPtr plasmarc = KSharedConfig::openConfig(QStandardPaths::locate(QStandardPaths::GenericConfigLocation, "plasmarc"), KSharedConfig::CascadeConfig);
-    KConfigGroup(plasmarc, "Theme").writeEntry("name", plasmaStyle);
-}
-
-void PlasmaStyle::setPlasmaStyleBreeze()
-{
-    KSharedConfigPtr plasmarc = KSharedConfig::openConfig(QStandardPaths::locate(QStandardPaths::GenericConfigLocation, "plasmarc"), KSharedConfig::CascadeConfig);
-    KConfigGroup(plasmarc, "Theme").deleteGroup();
+    styleProcess = new QProcess;
+    QString style = "/usr/bin/plasma-apply-desktoptheme";
+    QStringList styleArgs = {plasmaStyle};
+    styleProcess->start(style, styleArgs);
+    styleProcess->waitForFinished();
+    styleProcess->close();
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -280,28 +280,14 @@ void Utils::goLightStyle()
 {
     if (settings->value("PlasmaStyle/enabled").toBool())
     {
-        if (settings->value("PlasmaStyle/light") == "breeze") // Breeze style is set differently from others
-        {
-            plasmastyle.setPlasmaStyleBreeze();
-        }
-        else
-        {
-            plasmastyle.setPlasmaStyle(settings->value("PlasmaStyle/light").toString());
-        }
+        plasmastyle.setPlasmaStyle(settings->value("PlasmaStyle/light").toString());
     }
 }
 void Utils::goDarkStyle()
 {
     if (settings->value("PlasmaStyle/enabled").toBool())
     {
-        if (settings->value("PlasmaStyle/dark") == "breeze") // Breeze style is set differently from others
-        {
-            plasmastyle.setPlasmaStyleBreeze();
-        }
-        else
-        {
-            plasmastyle.setPlasmaStyle(settings->value("PlasmaStyle/dark").toString());
-        }
+        plasmastyle.setPlasmaStyle(settings->value("PlasmaStyle/dark").toString());
     }
 }
 void Utils::goLightColors()
@@ -389,20 +375,31 @@ void Utils::goDarkWall()
     }
 }
 /* this updates the style of both the plasma shell and latte dock if it is available 
+ * It also restart krunner to force the theme on it
 */
 void Utils::restartProcess()
 {
     if (settings->value("KvantumStyle/enabled").toBool())
     {
-        killAllProcess = new QProcess;
-        QString killAll = "/usr/bin/killall"; //used to kill a process
+        kquitapp5Process = new QProcess;
+        QString kquitapp5 = "/usr/bin/kquitapp5";
 
         kstart5Process = new QProcess;
         QString kstart5 = "/usr/bin/kstart5";
         QStringList plasmashell = {"plasmashell"};
 
-        killAllProcess->start(killAll, plasmashell);
-        kstart5Process->start(kstart5, plasmashell);
+        // kill plasma shell and wait for it
+        kquitapp5Process->start(kquitapp5, plasmashell);
+        kquitapp5Process->waitForFinished();
+        kquitapp5Process->close();
 
+        // start new process
+        kstart5Process->start(kstart5, plasmashell);
     }
+
+    // restart krunner
+    krunnerProcess = new QProcess;
+    QString krunner = "/usr/bin/krunner";
+    QStringList krunner_args = {"--replace", "-d"};
+    krunnerProcess->start(krunner, krunner_args);
 }


### PR DESCRIPTION
- add restart of krunner to refresh its theme.
- modify the way to change plasma-style using `plasma-apply-desktoptheme`. Now it shoulds be more consistant (especially with plasma 5.26 and further versions) and the modification reduces the complexity of the code.
- improve the plasma restart code for kavantum. It replaces the usage of kill with kquitapp5 to be able to wait before starting plasmashell. It may improve stability of plasma-shell restart by avoiding some failures due to starting plasmashell while the previous process did not finish.

These modifications solve #63 and #56 and may resolve #59 (I was unable to reproduce this bug)