### PR TITLE
Fix: Version field for validation of the desktop file

### DIFF
--- a/src/koi.desktop
+++ b/src/koi.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=1.2.3
+Version=1.2
 Name=Koi
 GenericName=Theme Switcher
 Comment=Scheduled LIGHT/DARK Theme Switching for the KDE Plasma Desktop


### PR DESCRIPTION
Fix the version to pass the vaidation.
`1.2.3` does not seem to be a Valid version.

From the build log:
```
+ desktop-file-validate /builddir/build/BUILDROOT/Koi-0.2.4-1.fc37.x86_64/usr/share/applications/koi.desktop
/builddir/build/BUILDROOT/Koi-0.2.4-1.fc37.x86_64/usr/share/applications/koi.desktop: error: value "1.2.3" for key "Version" in group "Desktop Entry" is not a known version
```

this was checked with the desktop-file-utils on fedora.

According to the docs a valid values are the specification versions ( 1.0 - 1.5 )
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys

I made a quick fix for the build on copr to allow the validation.