### PR TITLE
Patch to add wheel click toggle

### DIFF
--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -27,6 +27,13 @@ class Utils : public QObject
     Q_OBJECT
 
 public:
+    enum Mode {
+        Undefined = 0,
+        Dark = 1,
+        Light = 2,
+    };
+    Q_ENUM(Mode)
+
     Utils();
 
     QSettings *settings;
@@ -44,6 +51,7 @@ public:
     void startupTimeCheck();
     void startupSunCheck();
 
+    void toggle();
     void goLight();
     void goDark();
     void goLightStyle();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -78,6 +78,9 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) // Defi
                 //case QSystemTrayIcon::MiddleClick: // Middle-click to toggle between light and dark
                 //    utils.notify("Hello!", "You middle-clicked me", 0); // Must implement toggle
                 //    break;
+    case QSystemTrayIcon::MiddleClick: // Middle-click to toggle between light and dark
+        utils.toggle();
+        break;
 
         // Must understand tray better - Why can't right click be part of switch statement?
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -248,6 +248,16 @@ QStringList Utils::getKvantumStyles(void) // Get all available kvantum styles
     return kvantumStyles;
 }
 // Manage switching themes functions
+void Utils::toggle()
+{
+  QMetaEnum metaEnum = QMetaEnum::fromType<Mode>();
+  const auto current = settings->value("current", QVariant::fromValue(Mode::Undefined)).value<Mode>();
+  if (current == Mode::Light) {
+    goDark();
+  } else if (current == Mode::Dark) {
+    goLight();
+  }
+}
 void Utils::goLight()
 {
     goLightStyle();
@@ -261,6 +271,7 @@ void Utils::goLight()
     {
         notify("Switched to light mode!", "Some applications may need to be restarted for applied changes to take effect.");
     }
+    settings->setValue("current", QVariant::fromValue(Mode::Light).toString());
 }
 void Utils::goDark()
 {
@@ -275,6 +286,7 @@ void Utils::goDark()
     {
         notify("Switched to dark mode!", "Some applications may need to be restarted for applied changes to take effect.");
     }
+    settings->setValue("current", QVariant::fromValue(Mode::Dark).toString());
 }
 void Utils::goLightStyle()
 {


### PR DESCRIPTION
This is a continuation of https://github.com/baduhai/Koi/pull/72 and resolves https://github.com/baduhai/Koi/issues/84

Another try, since on my machine there is no more wayland error...

Also, extended the writing of the QSettings->setValue with .toString() to get rid of QVariant errors when reading back the settings.

Machine Setup, where this works:
```
Operating System: EndeavourOS 
KDE Plasma Version: 6.0.5
KDE Frameworks Version: 6.3.0
Qt Version: 6.7.1
Kernel Version: 6.9.4-zen1-1-zen (64-bit)
Graphics Platform: Wayland
Processors: 32 × AMD Ryzen 9 7950X 16-Core Processor
Memory: 93,5 GiB of RAM
Graphics Processor: NVIDIA GeForce RTX 4090/PCIe/SSE2
Manufacturer: ASUS
```