### PR TITLE
Adding option to run bash scripts at light/dark shift

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(koi
     plasmastyle.cpp headers/plasmastyle.h
     utils.cpp headers/utils.h
     wallpaper.cpp headers/wallpaper.h
+    script.cpp headers/script.h
     
     main.cpp
 )

--- a/src/headers/mainwindow.h
+++ b/src/headers/mainwindow.h
@@ -57,6 +57,7 @@ private slots:
     void on_gtkCheckBox_stateChanged(int arg1);
     void on_kvantumStyleCheckBox_stateChanged(int arg1);
     void on_wallCheckBox_stateChanged(int arg1);
+    void on_scriptCheckBox_stateChanged(int arg1);
     void on_autoCheckBox_stateChanged(int arg1);
     void on_scheduleRadioBtn_toggled(bool checked);
 
@@ -68,6 +69,8 @@ private slots:
 
     void on_lightWallBtn_clicked();
     void on_darkWallBtn_clicked();
+    void on_lightScriptBtn_clicked();
+    void on_darkScriptBtn_clicked();
     void on_lightDropStyle_currentTextChanged(const QString &arg1);
     void on_darkDropStyle_currentTextChanged(const QString &arg1);
     void on_lightDropColor_currentIndexChanged(int index);
@@ -103,6 +106,8 @@ private:
     QString darkGtk;
     QString lightWall;
     QString darkWall;
+    QString lightScript;
+    QString darkScript;
     QString lightKvantumStyle;
     QString darkKvantumStyle;
     QString lightTime;

--- a/src/headers/script.h
+++ b/src/headers/script.h
@@ -1,0 +1,17 @@
+#ifndef SCRIPT_H
+#define SCRIPT_H
+
+#include <QString>
+#include <QProcess>
+
+class Script
+{
+public:
+    Script();
+
+    void runScript(QString scriptFile);
+
+private:
+    QProcess *scriptProcess;
+};
+#endif // SCRIPT_H

--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -7,6 +7,7 @@
 #include "wallpaper.h"
 #include "icons.h"
 #include "kvantumstyle.h"
+#include "script.h"
 
 // Qt libraries
 #include <QtGlobal>
@@ -66,6 +67,8 @@ public:
     void goDarkKvantumStyle();
     void goLightWall();
     void goDarkWall();
+    void goLightScript();
+    void goDarkScript();
     void restartProcess();
 
 private:
@@ -75,6 +78,7 @@ private:
     Gtk gtk;
     Wallpaper wallpaper;
     KvantumStyle kvantumStyle;
+    Script script;
 
     QDBusConnection *bus;
     QDBusInterface *notifyInterface;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -245,7 +245,39 @@ void MainWindow::loadPrefs()
     {
         ui->darkWallBtn->setText(darkWallBtnText);
     }
+
+    // Load Script prefs
+    if (utils.settings->value("Script/enabled").toBool())
+    {
+        ui->scriptCheckBox->setChecked(true);
+    }
+    else
+    {
+        ui->scriptCheckBox->setChecked(false);
+    }
+    QFileInfo ls(utils.settings->value("Script/light").toString());
+    QString lightScriptBtnText = ls.fileName();
+    if (lightScript.isEmpty())
+    {
+        ui->lightScriptBtn->setText("Select...");
+    }
+    else
+    {
+        ui->lightScriptBtn->setText(lightScriptBtnText);
+    }
+    QFileInfo ds(utils.settings->value("Script/dark").toString());
+    QString darkScriptBtnText = ds.fileName();
+    if (darkScript.isEmpty())
+    {
+        ui->darkScriptBtn->setText("Select...");
+    }
+    else
+    {
+        ui->darkScriptBtn->setText(darkScriptBtnText);
+    }
+    
 }
+
 void MainWindow::savePrefs()
 {
     // Plasma Style enabling
@@ -325,6 +357,20 @@ void MainWindow::savePrefs()
     // Wallpaper saving prefs
     utils.settings->setValue("Wallpaper/light", lightWall);
     utils.settings->setValue("Wallpaper/dark", darkWall);
+    utils.settings->sync();
+
+    // Script enabling
+    if (ui->scriptCheckBox->isChecked() == 0)
+    {
+        utils.settings->setValue("Script/enabled", false);
+    }
+    else
+    {
+        utils.settings->setValue("Script/enabled", true);
+    }
+    // Script saving prefs
+    utils.settings->setValue("Script/light", lightScript);
+    utils.settings->setValue("Script/dark", darkScript);
     utils.settings->sync();
 }
 void MainWindow::refreshDirs() // Refresh function to find new themes
@@ -452,6 +498,18 @@ int MainWindow::prefsSaved() // Lots of ifs, don't know how to do it any other w
     {
         return 0;
     }
+    if (ui->scriptCheckBox->isChecked() != utils.settings->value("Script/enabled").toBool())
+    {
+        return 0;
+    }
+    if (lightScript != utils.settings->value("Script/light").toString())
+    {
+        return 0;
+    }
+    if (darkScript != utils.settings->value("Script/dark").toString())
+    {
+        return 0;
+    }
     return 1;
 }
 void MainWindow::scheduleLight()
@@ -540,6 +598,9 @@ void MainWindow::on_prefsBtn_clicked() // Preferences button - Sets all preferen
      * the wallpapers, the wallpaper preferences would be set as empty strings, and not stay
      * the same, as is expected behaviour. Unsure why this fixes said bug... ¯\_(ツ)_/¯
      */
+    lightScript = utils.settings->value("Script/light").toString();
+    darkScript = utils.settings->value("Script/dark").toString();
+    // Added the above lines in just in case the same bug affects setting the script properly
     loadPrefs();
     ui->mainStack->setCurrentIndex(1);
 }
@@ -568,6 +629,8 @@ void MainWindow::on_backBtn_clicked() // Back button in preferences view - Must 
             ui->mainStack->setCurrentIndex(0);
             lightWall = utils.settings->value("Wallpaper/light").toString();
             darkWall = utils.settings->value("Wallpaper/dark").toString();
+            lightScript = utils.settings->value("Script/light").toString();
+            darkScript = utils.settings->value("Script/dark").toString();
             loadPrefs();
             break;
         case QMessageBox::Cancel: // Do nothin  //probably dont need this case
@@ -695,6 +758,29 @@ void MainWindow::on_darkWallBtn_clicked() // Set dark wallpaper
     QString darkWallName = dw.fileName();
     ui->darkWallBtn->setText(darkWallName);
     ui->darkWallBtn->setToolTip(darkWall);
+}
+void MainWindow::on_scriptCheckBox_stateChanged(int scriptEnabled) // Script checkbox logic
+{
+        ui->darkScript->setEnabled(scriptEnabled);
+        ui->lightScript->setEnabled(scriptEnabled);
+        ui->darkScriptBtn->setEnabled(scriptEnabled);
+        ui->lightScriptBtn->setEnabled(scriptEnabled);
+}
+void MainWindow::on_lightScriptBtn_clicked() // Set light script
+{
+    lightScript = QFileDialog::getOpenFileName(this, tr("Select Script"), QDir::homePath(), tr("Bash script files(*.sh)"));
+    QFileInfo lw(lightScript);
+    QString lightScriptName = lw.fileName();
+    ui->lightScriptBtn->setText(lightScriptName);
+    ui->lightScriptBtn->setToolTip(lightScript);
+}
+void MainWindow::on_darkScriptBtn_clicked() // Set dark script
+{
+    darkScript = QFileDialog::getOpenFileName(this, tr("Select Script"), QDir::homePath(), tr("Bash script files(*.sh)"));
+    QFileInfo dw(darkScript);
+    QString darkScriptName = dw.fileName();
+    ui->darkScriptBtn->setText(darkScriptName);
+    ui->darkScriptBtn->setToolTip(darkScript);
 }
 void MainWindow::on_autoCheckBox_stateChanged(int automaticEnabled) // Logic for enabling scheduling of themes
 {

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -8,9 +8,18 @@ Script::Script()
 void Script::runScript(QString scriptFile)
 {
     scriptProcess = new QProcess;
-    QString bash = "/bin/bash";
+
+    QString locateProgram = "which";
+    QStringList programToLocate = {"bash"};
+
+    scriptProcess->start(locateProgram, programToLocate);
+    scriptProcess->waitForFinished();
+
+    QString program(scriptProcess->readAllStandardOutput());
+    program.replace("\n", "");
+    
     QStringList arguments{"-c", scriptFile};
-    scriptProcess->start(bash, arguments);
+    scriptProcess->start(program, arguments);
     scriptProcess->waitForFinished();
     scriptProcess->close();
 }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1,0 +1,16 @@
+#include "headers/script.h"
+
+Script::Script()
+{
+
+}
+
+void Script::runScript(QString scriptFile)
+{
+    scriptProcess = new QProcess;
+    QString bash = "/bin/bash";
+    QStringList arguments{"-c", scriptFile};
+    scriptProcess->start(bash, arguments);
+    scriptProcess->waitForFinished();
+    scriptProcess->close();
+}

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -677,6 +677,77 @@
               </item>
              </layout>
             </item>
+            <item row="7" column="0" colspan="2">
+              <layout class="QVBoxLayout" name="script">
+               <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="scriptCheckBox">
+                 <property name="text">
+                  <string>Run bash script</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_16">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <widget class="QLabel" name="lightScript">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>LIGHT:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <widget class="QLabel" name="darkScript">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>DARK:</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_17">
+                 <item>
+                  <widget class="QPushButton" name="lightScriptBtn">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Select...</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="darkScriptBtn">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Select...</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
            </layout>
           </widget>
          </widget>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -398,7 +398,7 @@ void Utils::goLightScript()
         }
         else
         {
-            notify("Error setting script", "Koi tried to run your script, but no script file was selected", 0);
+            notify("Error running script", "Koi tried to run your script, but no script file was selected", 0);
         }
     }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -266,6 +266,7 @@ void Utils::goLight()
     goLightGtk();
     goLightKvantumStyle();
     goLightWall();
+    goLightScript();
     restartProcess();
     if (settings->value("notify").toBool())
     {
@@ -281,6 +282,7 @@ void Utils::goDark()
     goDarkGtk();
     goDarkKvantumStyle();
     goDarkWall();
+    goDarkScript();
     restartProcess();
     if (settings->value("notify").toBool())
     {
@@ -368,7 +370,7 @@ void Utils::goLightWall()
         }
         else
         {
-            notify("Error setting Wallpaper", "Koi tried to change your wallpaper, but no wallpaper fie was selected", 0);
+            notify("Error setting Wallpaper", "Koi tried to change your wallpaper, but no wallpaper file was selected", 0);
         }
     }
 }
@@ -386,7 +388,35 @@ void Utils::goDarkWall()
         }
     }
 }
-/* this updates the style of both the plasma shell and latte dock if it is available 
+void Utils::goLightScript()
+{
+    if (settings->value("Script/enabled").toBool())
+    {
+        if (!settings->value("Script/light").isNull())
+        {
+            script.runScript(settings->value("Script/light").toString());
+        }
+        else
+        {
+            notify("Error setting script", "Koi tried to run your script, but no script file was selected", 0);
+        }
+    }
+}
+void Utils::goDarkScript()
+{
+    if (settings->value("Script/enabled").toBool())
+    {
+        if (!settings->value("Script/dark").isNull())
+        {
+            script.runScript(settings->value("Script/dark").toString());
+        }
+        else
+        {
+            notify("Error running script", "Koi tried to run your script, but no script file was selected", 0);
+        }
+    }
+}
+/* this updates the style of both the plasma shell and latte  dock if it is available 
  * It also restart krunner to force the theme on it
 */
 void Utils::restartProcess()


### PR DESCRIPTION
I've added an option to my install of Koi where you can pick your own bash scripts to run at the light colour shift and at the dark colour shift. The option is visible in the Preferences menu under Wallpaper. I've tested it on my Arch install running KDE Plasma 6 and it looks like it's working fine, thought I should put in a PR just in case this is a feature you'd be interested in :-)