### PR TITLE
[BUG] not all kvantum themes are showing #98

### DIFF
--- a/src/plugins/kvantumstyle.cpp
+++ b/src/plugins/kvantumstyle.cpp
@@ -11,18 +11,21 @@ QStringList KvantumStyle::getThemes() {
   QDir kvantumStyleLocalDir(QDir::homePath() + "/.config/Kvantum");
   QDir kvantumStyleSystemDir("/usr/share/Kvantum");
   QDir kvantumStyleNixDir("/var/run/current-system/sw/Kvantum");
+  QDir kvantumStyleDirs[] = {kvantumStyleLocalDir, kvantumStyleSystemDir, kvantumStyleNixDir};
   QStringList kvantumStyles;
-  if (kvantumStyleLocalDir.exists()) {
-    kvantumStyles.append(
-        kvantumStyleLocalDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot));
-  }
-  if (kvantumStyleSystemDir.exists()) {
-    kvantumStyles.append(
-        kvantumStyleSystemDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot));
-  }
-  if (kvantumStyleNixDir.exists()) {
-    kvantumStyles.append(
-        kvantumStyleNixDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot));
+  for (const auto& dir : kvantumStyleDirs) {
+    if (dir.exists()) {
+        //Navigate subdirectories
+        for (const auto& entry : dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot)) {
+            //Check inside the directory for all ".kconfig" files
+            QDir subDir(entry.absoluteFilePath());
+            for (const auto& subEntry : subDir.entryInfoList(QDir::Files)) {
+                if (subEntry.suffix() == "kvconfig") {
+                    kvantumStyles.append(subEntry.baseName());
+                }
+            }
+        }
+    }
   }
   kvantumStyles.removeDuplicates();
   kvantumStyles.sort();


### PR DESCRIPTION
Following pc-v2 debugging to try to detect the .kvconfig files into subdirectories instead of simply the directories.

Tested only with layan themes on arch 