### PR TITLE
Add DBus interface for changing light/dark mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,11 +82,6 @@ target_compile_definitions(koi PUBLIC
     QT_DEPRECATED_WARNINGS
 )
 
-target_include_directories(koi PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 target_link_libraries(koi PUBLIC
     KF6::ConfigCore
     KF6::ConfigGui

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,8 +28,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Gui Network Test)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Xml)
 
-
-add_executable(koi
+set(koi_SRC
     # Main app stuff.
     about.cpp
     license.cpp
@@ -40,6 +39,13 @@ add_executable(koi
     headers/license.h
     headers/mainwindow.h
     headers/utils.h
+    # DBus interface stuff
+    dbusinterface.cpp
+    headers/dbusinterface.h
+    # DBus interface XML file -- generated at build time
+    ${CMAKE_CURRENT_BINARY_DIR}/dev.baduhai.Koi.xml
+    # DBus interface adapter -- generated at build time from the XML file
+    ${CMAKE_CURRENT_BINARY_DIR}/koiadaptor.h
     # UI items
     resources/resources.qrc
     ui/about.ui
@@ -59,8 +65,26 @@ add_executable(koi
     main.cpp
 )
 
+qt_generate_dbus_interface(headers/dbusinterface.h
+    dev.baduhai.Koi.xml
+    OPTIONS -A
+)
+
+qt_add_dbus_adaptor(koi_SRC ${CMAKE_CURRENT_BINARY_DIR}/dev.baduhai.Koi.xml
+                     headers/dbusinterface.h KoiDbusInterface)
+
+
+add_executable(koi
+    ${koi_SRC}
+)
+
 target_compile_definitions(koi PUBLIC
     QT_DEPRECATED_WARNINGS
+)
+
+target_include_directories(koi PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(koi PUBLIC
@@ -82,4 +106,5 @@ install(TARGETS koi
     RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
     BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
     LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/dev.baduhai.Koi.xml DESTINATION ${DBUS_INTERFACES_INSTALL_DIR}
 )

--- a/src/dbusinterface.cpp
+++ b/src/dbusinterface.cpp
@@ -1,0 +1,30 @@
+#include <QObject>
+#include "headers/utils.h"
+#include "koiadaptor.h"
+
+KoiDbusInterface::KoiDbusInterface(QObject* parent) : QObject(parent) {
+    new KoiDbusInterfaceAdaptor(this);
+    QDBusConnection dbus = QDBusConnection::sessionBus();
+    dbus.registerObject("/Koi", this);
+    dbus.registerService("dev.baduhai.Koi");
+    this->utils.initialiseSettings();
+}
+
+KoiDbusInterface::~KoiDbusInterface() {
+    QDBusConnection dbus = QDBusConnection::sessionBus();
+    dbus.unregisterService("dev.baduhai.Koi");
+    dbus.unregisterObject("/Koi");
+}
+
+
+void KoiDbusInterface::goLightMode() {
+    utils.goLight();
+}
+
+void KoiDbusInterface::goDarkMode() {
+    utils.goDark();
+}
+
+void KoiDbusInterface::toggleMode() {
+    utils.toggle();
+}

--- a/src/dbusinterface.cpp
+++ b/src/dbusinterface.cpp
@@ -7,7 +7,7 @@ KoiDbusInterface::KoiDbusInterface(QObject* parent) : QObject(parent) {
     QDBusConnection dbus = QDBusConnection::sessionBus();
     dbus.registerObject("/Koi", this);
     dbus.registerService("dev.baduhai.Koi");
-    this->utils.initialiseSettings();
+    utils.initialiseSettings();
 }
 
 KoiDbusInterface::~KoiDbusInterface() {

--- a/src/headers/dbusinterface.h
+++ b/src/headers/dbusinterface.h
@@ -1,0 +1,19 @@
+#include <QObject>
+#include "headers/utils.h"
+
+class KoiDbusInterface : public QObject {
+    Q_OBJECT
+    Q_CLASSINFO("Koi D-Bus Interface", "dev.baduhai.Koi")
+
+    public:
+        KoiDbusInterface(QObject* parent);
+        ~KoiDbusInterface();
+
+    public Q_SLOTS:
+        void goLightMode();
+        void goDarkMode();
+        void toggleMode();
+
+    private:
+        Utils utils;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "headers/mainwindow.h"
 #include "headers/utils.h"
+#include "headers/dbusinterface.h"
 
 #include <iostream>
 #include <QApplication>
@@ -39,7 +40,7 @@ int main(int argc, char *argv[])
         {
             w.show();
         }
+        KoiDbusInterface dbusIf(&a);
         return a.exec();
     }
 }
-


### PR DESCRIPTION
Seeing some of the discussion in https://github.com/baduhai/Koi/issues/10 and using Koi myself, I'd like to be able to use a keyboard shortcut (or an Albert plugin) to toggle light/dark mode.

I saw [this tutorial](https://techbase.kde.org/Development/Tutorials/D-Bus/Creating_Interfaces) linked from that discussion, and decided to try my hand at following it.

**I AM NOT A C++ DEVELOPER, AND I'VE NEVER WORKED WITH QT BEFORE**.

...so please take this contribution with a grain of salt! I fumbled my way there through programming know-how from other languages, docs, and occasionally asking an AI what stuff in CMake means.