### PR TITLE
Several memory leak fixes; and does not start krunner as a child process

### DIFF
--- a/src/headers/plugin.h
+++ b/src/headers/plugin.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QProcess>
 #include <QString>
 #include <QStringList>
 #include <QtDBus>
@@ -15,12 +14,5 @@ public:
 // Plugin that handles theme switching via DBus communication.
 class DbusPlugin : Plugin {
 protected:
-  QDBusConnection *bus;
-  QDBusInterface *interface;
-};
-
-// Plugin that handles theme switching via an external process.
-class ProcessPlugin : Plugin {
-protected:
-  QProcess *process;
+  QDBusInterface* interface = nullptr;
 };

--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 // Qt libraries
 #include <QDateTime>
 #include <QDir>
@@ -32,7 +34,7 @@ public:
 
   Utils();
 
-  QSettings *settings;
+  std::unique_ptr<QSettings> settings;
   void initialiseSettings();
 
   QStringList getPlasmaStyles(void);
@@ -75,11 +77,5 @@ private:
   KvantumStyle kvantumStyle;
   Script script;
 
-  QDBusConnection *bus;
-  QDBusInterface *notifyInterface;
-  QProcess *plasmaDesktopProcess;
-  QProcess *latteProcess;
-  QProcess *kquitappProcess;
-  QProcess *kstartProcess;
-  QProcess *krunnerProcess;
+  QDBusInterface* notifyInterface;
 };

--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -77,5 +77,5 @@ private:
   KvantumStyle kvantumStyle;
   Script script;
 
-  QDBusInterface* notifyInterface;
+  QDBusInterface* notifyInterface = nullptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "headers/utils.h"
 
 #include <iostream>
+#include <memory>
 #include <QApplication>
 #include <QLocalSocket>
 #include <QLocalServer>
@@ -15,11 +16,12 @@ bool isAlreadyRunning(QString netName)
     return isOpen;
 }
 
-void createDummyNetwork(QString netName)
+std::unique_ptr<QLocalServer> createDummyNetwork(QString netName)
 {
-    QLocalServer* server = new QLocalServer;
+    auto server = std::make_unique<QLocalServer>();
     server->setSocketOptions(QLocalServer::WorldAccessOption);
     server->listen(netName);
+    return server;
 }
 
 int main(int argc, char *argv[])
@@ -30,7 +32,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        createDummyNetwork("koiDummyNetwork");
+        const auto dummyServer = createDummyNetwork("koiDummyNetwork");
         Utils utils;
         utils.initialiseSettings();
         QApplication a(argc, argv);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -40,7 +40,10 @@ MainWindow::MainWindow(QWidget *parent)
           &MainWindow::on_actionRestart_triggered);
   ui->resMsg->addAction(actionRes);
 }
-MainWindow::~MainWindow() { this->setVisible(0); }
+MainWindow::~MainWindow() {
+    this->setVisible(0);
+    delete ui;
+}
 
 // Override window managing events
 void MainWindow::closeEvent(QCloseEvent *event) { // Overide close event

--- a/src/plugins/colorscheme.cpp
+++ b/src/plugins/colorscheme.cpp
@@ -1,20 +1,21 @@
 #include "colorscheme.h"
 
-void ColorScheme::setTheme(QString themeName) {
-  process = new QProcess;
+#include <QProcess>
 
+void ColorScheme::setTheme(QString themeName) {
+  QProcess process;
   QString locateProgram = "whereis";
   QStringList programToLocate = {"plasma-apply-colorscheme"};
 
-  process->start(locateProgram, programToLocate);
-  process->waitForFinished();
+  process.start(locateProgram, programToLocate);
+  process.waitForFinished();
 
-  QString program(process->readAllStandardOutput());
+  QString program(process.readAllStandardOutput());
   program.replace("plasma-apply-colorscheme: ", "");
   program.replace("\n", "");
 
   QStringList arguments{themeName};
-  process->start(program, arguments);
+  QProcess::startDetached(program, arguments);
 }
 
 QStringList ColorScheme::getThemes() {

--- a/src/plugins/colorscheme.h
+++ b/src/plugins/colorscheme.h
@@ -2,7 +2,7 @@
 
 #include "headers/plugin.h"
 
-class ColorScheme : protected ProcessPlugin {
+class ColorScheme : protected Plugin {
 public:
   void setTheme(QString themeName) override;
   QStringList getThemes() override;

--- a/src/plugins/gtk.cpp
+++ b/src/plugins/gtk.cpp
@@ -1,9 +1,13 @@
 #include "gtk.h"
 
 void Gtk::setTheme(QString theme) {
-  bus = new QDBusConnection(QDBusConnection::sessionBus());
-  interface = new QDBusInterface("org.kde.GtkConfig", "/GtkConfig",
-                                 "org.kde.GtkConfig", *bus);
+
+  if(!interface)
+  {
+      interface = new QDBusInterface("org.kde.GtkConfig", "/GtkConfig",
+                                         "org.kde.GtkConfig", QDBusConnection::sessionBus());
+  }
+
   interface->call("setGtk2Theme", theme);
   interface->call("setGtk3Theme", theme);
   interface->call("setGtkTheme", theme);

--- a/src/plugins/icons.cpp
+++ b/src/plugins/icons.cpp
@@ -1,22 +1,24 @@
 #include "icons.h"
 
+#include <QProcess>
+
 void Icons::setTheme(QString iconTheme) {
-  process = new QProcess;
 
   // locate plasma-changeicons program
+  QProcess process;
   QString locateProgram = "whereis";
   QStringList programToLocate = {"plasma-changeicons"};
 
-  process->start(locateProgram, programToLocate);
-  process->waitForFinished();
+  process.start(locateProgram, programToLocate);
+  process.waitForFinished();
 
-  QString program(process->readAllStandardOutput());
+  QString program(process.readAllStandardOutput());
   program.replace("plasma-changeicons: ", "");
   program.replace("\n", "");
 
   // apply the icon theme
   QStringList arguments{iconTheme};
-  process->start(program, arguments);
+  QProcess::startDetached(program, arguments);
 }
 
 QStringList Icons::getThemes() {

--- a/src/plugins/icons.h
+++ b/src/plugins/icons.h
@@ -2,7 +2,7 @@
 
 #include "headers/plugin.h"
 
-class Icons : ProcessPlugin {
+class Icons : Plugin {
 public:
   void setTheme(QString iconTheme) override;
   QStringList getThemes() override;

--- a/src/plugins/kvantumstyle.cpp
+++ b/src/plugins/kvantumstyle.cpp
@@ -1,10 +1,10 @@
 #include "kvantumstyle.h"
 
+#include <QProcess>
+
 void KvantumStyle::setTheme(QString kvantumStyle) {
-  process = new QProcess;
-  QString program = "/usr/bin/kvantummanager";
   QStringList arguments{"--set", kvantumStyle};
-  process->start(program, arguments);
+  QProcess::startDetached("/usr/bin/kvantummanager", arguments);
 }
 
 QStringList KvantumStyle::getThemes() {

--- a/src/plugins/kvantumstyle.h
+++ b/src/plugins/kvantumstyle.h
@@ -2,7 +2,7 @@
 
 #include "headers/plugin.h"
 
-class KvantumStyle : ProcessPlugin {
+class KvantumStyle : Plugin {
 public:
   void setTheme(QString kvantumStyle) override;
   QStringList getThemes() override;

--- a/src/plugins/plasmastyle.cpp
+++ b/src/plugins/plasmastyle.cpp
@@ -1,12 +1,10 @@
 #include "plasmastyle.h"
 
+#include <QProcess>
+
 void PlasmaStyle::setTheme(QString plasmaStyle) {
-  process = new QProcess;
-  QString style = "/usr/bin/plasma-apply-desktoptheme";
   QStringList styleArgs = {plasmaStyle};
-  process->start(style, styleArgs);
-  process->waitForFinished();
-  process->close();
+    QProcess::execute("/usr/bin/plasma-apply-desktoptheme", styleArgs);
 }
 
 QStringList PlasmaStyle::getThemes(void) {

--- a/src/plugins/plasmastyle.h
+++ b/src/plugins/plasmastyle.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "headers/plugin.h"
-class PlasmaStyle : ProcessPlugin {
+class PlasmaStyle : Plugin {
 public:
   void setTheme(QString plasmaStyle) override;
   QStringList getThemes() override;

--- a/src/plugins/script.cpp
+++ b/src/plugins/script.cpp
@@ -1,19 +1,19 @@
 #include "script.h"
 
-void Script::setTheme(QString scriptFile) {
-  process = new QProcess;
+#include <QProcess>
 
+void Script::setTheme(QString scriptFile) {
+
+  QProcess process;
   QString locateProgram = "which";
   QStringList programToLocate = {"bash"};
 
-  process->start(locateProgram, programToLocate);
-  process->waitForFinished();
+  process.start(locateProgram, programToLocate);
+  process.waitForFinished();
 
-  QString program(process->readAllStandardOutput());
+  QString program(process.readAllStandardOutput());
   program.replace("\n", "");
 
   QStringList arguments{"-c", scriptFile};
-  process->start(program, arguments);
-  process->waitForFinished();
-  process->close();
+  QProcess::execute(program, arguments);
 }

--- a/src/plugins/script.h
+++ b/src/plugins/script.h
@@ -2,7 +2,7 @@
 
 #include "headers/plugin.h"
 
-class Script : ProcessPlugin {
+class Script : Plugin {
 public:
   void setTheme(QString scriptFile) override;
 };

--- a/src/plugins/wallpaper.cpp
+++ b/src/plugins/wallpaper.cpp
@@ -1,9 +1,12 @@
 #include "wallpaper.h"
 
 void Wallpaper::setTheme(QString wallFile) {
-  bus = new QDBusConnection(QDBusConnection::sessionBus());
-  interface = new QDBusInterface("org.kde.plasmashell", "/PlasmaShell",
-                                 "org.kde.PlasmaShell", *bus);
+
+  if(!interface)
+  {
+    interface = new QDBusInterface("org.kde.plasmashell", "/PlasmaShell",
+                        "org.kde.PlasmaShell", QDBusConnection::sessionBus());
+  }
   QString script = "var allDesktops = desktops();";
   script += "print (allDesktops);";
   script += "for (i=0;i<allDesktops.length;i++) {";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -243,5 +243,5 @@ void Utils::restartProcess() {
   }
 
   // stop krunner, it will be restarted when it is requested again
-  QProcess::execute("/usr/bin/kquitapp6", {"krunner"});
+  QProcess::startDetached("/usr/bin/kquitapp6", {"krunner"});
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,7 @@ Utils::Utils() {}
 // Global settings stuff
 void Utils::initialiseSettings() {
   settings =
-      new QSettings(QDir::homePath() + "/.config/koirc",
+      std::make_unique<QSettings>(QDir::homePath() + "/.config/koirc",
                     QSettings::IniFormat); // Setting config path and format
 }
 
@@ -14,10 +14,12 @@ void Utils::initialiseSettings() {
 void Utils::notify(QString notifySummary, QString notifyBody,
                    int timeoutms) // Push notification through DBus
 {
-  bus = new QDBusConnection(QDBusConnection::sessionBus());
-  notifyInterface = new QDBusInterface("org.freedesktop.Notifications",
+  if (!notifyInterface)
+  {
+    notifyInterface = new QDBusInterface("org.freedesktop.Notifications",
                                        "/org/freedesktop/Notifications",
-                                       "org.freedesktop.Notifications", *bus);
+                                       "org.freedesktop.Notifications", QDBusConnection::sessionBus());
+  }
   QString app_name = "Koi"; // What program is the notification coming from?
   uint replaces_id =
       0; // Not sure what this is. Think it has something to do with pid.
@@ -91,7 +93,6 @@ QStringList Utils::getGtkThemes(void) { return gtk.getThemes(); }
 QStringList Utils::getKvantumStyles(void) { return kvantumStyle.getThemes(); }
 // Manage switching themes functions
 void Utils::toggle() {
-  QMetaEnum metaEnum = QMetaEnum::fromType<Mode>();
   const auto current =
       settings->value("current", QVariant::fromValue(Mode::Undefined))
           .value<Mode>();
@@ -234,25 +235,13 @@ void Utils::goDarkScript() {
  */
 void Utils::restartProcess() {
   if (settings->value("KvantumStyle/enabled").toBool()) {
-    kquitappProcess = new QProcess;
-    QString kquitapp = "/usr/bin/kquitapp6";
 
-    kstartProcess = new QProcess;
-    QString kstart = "/usr/bin/kstart";
+    // restart plasmashell
     QStringList plasmashell = {"plasmashell"};
-
-    // kill plasma shell and wait for it
-    kquitappProcess->start(kquitapp, plasmashell);
-    kquitappProcess->waitForFinished();
-    kquitappProcess->close();
-
-    // start new process
-    kstartProcess->start(kstart, plasmashell);
+    QProcess::execute("/usr/bin/kquitapp6", plasmashell);
+    QProcess::startDetached("/usr/bin/kstart", plasmashell);
   }
 
-  // restart krunner
-  krunnerProcess = new QProcess;
-  QString krunner = "/usr/bin/krunner";
-  QStringList krunner_args = {"--replace", "-d"};
-  krunnerProcess->start(krunner, krunner_args);
+  // stop krunner, it will be restarted when it is requested again
+  QProcess::execute("/usr/bin/kquitapp6", {"krunner"});
 }


### PR DESCRIPTION
This PR fixes some memory leaks when exiting the program or whenever the themes get switched.

It also does not start krunner as a child process, it just quits it. 
krunner will self start if requested again. 

This will also not start krunner on systems, where krunner was not running before.

Refs #107 