### PR TITLE
chore: removes QTest as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ ___
  * QT 6 DBus
  * QT 6 Gui
  * QT 6 Network
- * QT 6 Test
  * QT 6 Widgets *(Optional)*
  * QT 6 Xml *(Optional)*
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(KF6Config)
 find_package(KF6CoreAddons)
 find_package(KF6WidgetsAddons)
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Gui Network Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Gui Network)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Xml)
 
@@ -72,7 +72,6 @@ target_link_libraries(koi PUBLIC
     Qt::DBus
     Qt::Gui
     Qt::Network
-    Qt::Test
     Qt::Widgets
     Qt::Xml
     Threads::Threads

--- a/src/headers/utils.h
+++ b/src/headers/utils.h
@@ -6,7 +6,6 @@
 #include <QObject>
 #include <QProcess>
 #include <QSettings>
-#include <QTest>
 #include <QTimer>
 #include <QtGlobal>
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,8 @@
 #include "headers/utils.h"
 #include "libraries/SunRise.h"
 
+#include <QThread>
+
 Utils::Utils() {}
 
 // Global settings stuff
@@ -41,21 +43,21 @@ void Utils::startupTimeCheck() // Switch to the theme set for the current time
       QTime::fromString(settings->value("time-dark").toString(), "hh:mm:ss");
   QTime now = QTime::currentTime();
   if (now < lightTime && now < darkTime) {
-    QTest::qWait(1000); // Needed delay, or Koi may use the wrong color scheme.
+    QThread::msleep(1000); // Needed delay, or Koi may use the wrong color scheme.
     goDark();
   } else if (now == lightTime) // Highly unlikely
   {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goLight();
   } else if (now > lightTime && now < darkTime) {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goLight();
   } else if (now == darkTime) // Highly unlikely
   {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goDark();
   } else {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goDark();
   }
 }
@@ -71,10 +73,10 @@ void Utils::startupSunCheck() { // Switch to the theme set for the current sun
   sr.calculate(latitude, longitude, t);
 
   if (sr.isVisible) {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goLight();
   } else {
-    QTest::qWait(1000);
+    QThread::msleep(1000);
     goDark();
   }
 }


### PR DESCRIPTION
QTest was just used for the a sleep function. This can be replaced with the sleep function in the core module