### PR TITLE
do not start scheduler when there is no schedule defined

### DIFF
--- a/src/headers/mainwindow.h
+++ b/src/headers/mainwindow.h
@@ -11,6 +11,10 @@
 // Headers
 #include "utils.h"
 
+namespace Bosma{
+class Scheduler;
+}
+
 QT_BEGIN_NAMESPACE
 namespace Ui {
 class MainWindow;
@@ -36,9 +40,9 @@ private slots:
   void savePrefs();
   void toggleVisibility();
   int prefsSaved();
-  void scheduleLight();
-  void scheduleDark();
-  void scheduleSunEvent();
+  void scheduleLight(Bosma::Scheduler& s);
+  void scheduleDark(Bosma::Scheduler& s);
+  void scheduleSunEvent(Bosma::Scheduler& s);
 
   void on_prefsBtn_clicked();
   void on_backBtn_clicked();
@@ -109,6 +113,7 @@ private:
   QString lightTime;
   QString darkTime;
   Utils utils;
+  std::unique_ptr<Bosma::Scheduler> scheduler;
 
 protected:
 };


### PR DESCRIPTION
When the scheduling feature is not used, Koi still starts 2 new threads for the scheduler. This is not really necessary.

This PR will only create the scheduler, when the scheduling feature is actually in use.