### PR TITLE
Replaces instance check with shared memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ ___
  * QT 6 Core
  * QT 6 DBus
  * QT 6 Gui
- * QT 6 Network
  * QT 6 Widgets
  * QT 6 Xml
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ find_package(KF6Config)
 find_package(KF6CoreAddons)
 find_package(KF6WidgetsAddons)
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Gui Network)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Gui)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Xml)
 
@@ -49,11 +49,13 @@ set(koi_SRC
     license.cpp
     mainwindow.cpp
     utils.cpp
+    runguard.cpp
     # QObject headers needs to be added as sources to properly run MOC and UIC.
     headers/about.h
     headers/license.h
     headers/mainwindow.h
     headers/utils.h
+    headers/runguard.h
     # DBus interface stuff
     dbusinterface.cpp
     headers/dbusinterface.h
@@ -105,7 +107,6 @@ target_link_libraries(koi PUBLIC
     Qt::Core
     Qt::DBus
     Qt::Gui
-    Qt::Network
     Qt::Widgets
     Qt::Xml
     Threads::Threads

--- a/src/headers/runguard.h
+++ b/src/headers/runguard.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <QObject>
+#include <QSharedMemory>
+#include <QSystemSemaphore>
+
+// from https://stackoverflow.com/questions/5006547/qt-best-practice-for-a-single-instance-app-protection
+class RunGuard
+{
+
+public:
+    RunGuard( const QString& key );
+    ~RunGuard();
+
+    bool isAnotherRunning();
+    bool tryToRun();
+    void release();
+
+private:
+
+    const QString key;
+    const QString memLockKey;
+    const QString sharedmemKey;
+
+    QSharedMemory sharedMem;
+    QSystemSemaphore memLock;
+
+    Q_DISABLE_COPY( RunGuard )
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,48 +1,29 @@
 #include "headers/mainwindow.h"
 #include "headers/utils.h"
 #include "headers/dbusinterface.h"
+#include "headers/runguard.h"
 
 #include <iostream>
 #include <memory>
 #include <QApplication>
-#include <QLocalSocket>
-#include <QLocalServer>
-
-bool isAlreadyRunning(QString netName)
-{
-    QLocalSocket socket;
-    socket.connectToServer(netName);
-    bool isOpen = socket.isOpen();
-    socket.close();
-    return isOpen;
-}
-
-std::unique_ptr<QLocalServer> createDummyNetwork(QString netName)
-{
-    auto server = std::make_unique<QLocalServer>();
-    server->setSocketOptions(QLocalServer::WorldAccessOption);
-    server->listen(netName);
-    return server;
-}
 
 int main(int argc, char *argv[])
 {
-    if (isAlreadyRunning("koiDummyNetwork"))
+    RunGuard rg("koiDummyNetwork");
+    if (!rg.tryToRun())
     {
         std::cout << "Another instance of Koi is already running" << std::endl;
+        return 1;
     }
-    else
+
+    Utils utils;
+    utils.initialiseSettings();
+    QApplication a(argc, argv);
+    MainWindow w;
+    if (utils.settings->value("start-hidden").toBool() == 0)
     {
-        const auto dummyServer = createDummyNetwork("koiDummyNetwork");
-        Utils utils;
-        utils.initialiseSettings();
-        QApplication a(argc, argv);
-        MainWindow w;
-        if (utils.settings->value("start-hidden").toBool() == 0)
-        {
-            w.show();
-        }
-        KoiDbusInterface dbusIf(&a);
-        return a.exec();
+        w.show();
     }
+    KoiDbusInterface dbusIf(&a);
+    return a.exec();
 }

--- a/src/runguard.cpp
+++ b/src/runguard.cpp
@@ -1,0 +1,80 @@
+#include "headers/runguard.h"
+
+#include <QCryptographicHash>
+
+
+namespace
+{
+
+QString generateKeyHash( const QString& key, const QString& salt )
+{
+    QByteArray data;
+
+    data.append( key.toUtf8() );
+    data.append( salt.toUtf8() );
+    data = QCryptographicHash::hash( data, QCryptographicHash::Sha1 ).toHex();
+
+    return data;
+}
+
+}
+
+
+RunGuard::RunGuard( const QString& key )
+    : key( key )
+    , memLockKey( generateKeyHash( key, "_memLockKey" ) )
+    , sharedmemKey( generateKeyHash( key, "_sharedmemKey" ) )
+    , sharedMem( sharedmemKey )
+    , memLock( memLockKey, 1 )
+{
+    memLock.acquire();
+    {
+        QSharedMemory fix( sharedmemKey );    // Fix for *nix: http://habrahabr.ru/post/173281/
+        fix.attach();
+    }
+    memLock.release();
+}
+
+RunGuard::~RunGuard()
+{
+    release();
+}
+
+bool RunGuard::isAnotherRunning()
+{
+    if ( sharedMem.isAttached() )
+        return false;
+
+    memLock.acquire();
+    const bool isRunning = sharedMem.attach();
+    if ( isRunning )
+        sharedMem.detach();
+    memLock.release();
+
+    return isRunning;
+}
+
+bool RunGuard::tryToRun()
+{
+    if ( isAnotherRunning() )   // Extra check
+        return false;
+
+    memLock.acquire();
+    const bool result = sharedMem.create( sizeof( quint64 ) );
+    memLock.release();
+    if ( !result )
+    {
+        release();
+        return false;
+    }
+
+    return true;
+}
+
+void RunGuard::release()
+{
+    memLock.acquire();
+    if ( sharedMem.isAttached() )
+        sharedMem.detach();
+    memLock.release();
+}


### PR DESCRIPTION
Koi checks, if another instance is running.

Current behaviour will start a server on a socket. If the socket is free, Koi starts, otherwise it refuses.

This PR replaces the server mechanic with a 8byte shared memory block. Only 1 single Koi instance can have exclusive access to it. If the Koi instance cannot get exclusive access to the shared memory block, it will not start. If Koi quits normally or crashes, the OS will free up the shared memory access.

Since we can remove the whole QNetwork dependency + do not have to listen to a socket, the memory usage is further reduces by ~2MB (mostly due to not loading libQt6Network.so).

It is also unlikely, that QNetwork will be required by Koi in the near future.
