### PR TITLE
[FEATURE] TrayManager: remove QIcon::fromTheme

### DIFF
--- a/src/trayManager.cpp
+++ b/src/trayManager.cpp
@@ -8,7 +8,10 @@ TrayManager::TrayManager(MainWindow *mainWindow, Utils *utils, QObject *parent)
     : QObject(parent), mainWindow(mainWindow), utils(utils) {
 
   trayIcon = new QSystemTrayIcon(this);
-  QIcon icon = QIcon::fromTheme("koi_tray", QIcon(":/resources/icons/koi_tray.png"));
+  // this can produce an invisible system tray icon
+  // https://bugreports.qt.io/browse/QTBUG-139779
+  // QIcon icon = QIcon::fromTheme("koi_tray", QIcon(":/resources/icons/koi_tray.png"));
+  QIcon icon = QIcon(":/resources/icons/koi_tray.png");
   trayIcon->setIcon(icon);
   trayIcon->setContextMenu(createMenu());
 


### PR DESCRIPTION
this can produce an invisible system tray icon

```cc
QIcon icon = QIcon::fromTheme("koi_tray", QIcon(":/resources/icons/koi_tray.png"));
```

this works

```cc
QIcon icon = QIcon(":/resources/icons/koi_tray.png");
```

upstream issue: https://bugreports.qt.io/browse/QTBUG-139779

fixme: in dark mode, the `koi_tray.png` icon should be white on transparent
